### PR TITLE
Naive message length

### DIFF
--- a/src/TerminalGame.RelayServer.WithBedrock/MessageExtensions.cs
+++ b/src/TerminalGame.RelayServer.WithBedrock/MessageExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Text;
+
+namespace TerminalGame.RelayServer.WithBedrock
+{
+    public static class MyRequestMessageExtensions
+    {
+        public static int GetMessageLength(this MyRequestMessage message) =>
+            message switch
+            {
+                InitMessage msg => msg.GetMessageLength(),
+                PayloadMessage msg => msg.GetMessageLength(),
+                _ => throw new InvalidOperationException($"Unsupported message type: {message.GetType().FullName}")
+            };
+
+        public const string EmptyInitJsonMessage = "{\"payloadType\":\"INIT\",\"source\":\"\"}";
+        public static int GetMessageLength(this InitMessage message)
+        {
+            var sourceLength = Encoding.UTF8.GetByteCount(message.Source);
+
+            return EmptyInitJsonMessage.Length + sourceLength;
+        }
+
+        public const string EmptyPayloadJsonMessage = "{\"payloadType\":\"MESSAGE\",\"destination\":\"\",\"source\":\"\",\"payload\":\"\"}";
+        public static int GetMessageLength(this PayloadMessage message)
+        {
+            var sourceLength = Encoding.UTF8.GetByteCount(message.Source);
+            var destinationLength = Encoding.UTF8.GetByteCount(message.Destination);
+            var payloadLength = Encoding.UTF8.GetByteCount(message.Payload);
+
+            return EmptyPayloadJsonMessage.Length + sourceLength + destinationLength + payloadLength;
+        }
+    }
+}

--- a/src/TerminalGame.RelayServer.WithBedrock/Messages.cs
+++ b/src/TerminalGame.RelayServer.WithBedrock/Messages.cs
@@ -1,5 +1,22 @@
-﻿namespace TerminalGame.RelayServer.WithBedrock
+﻿using System.IO;
+
+namespace TerminalGame.RelayServer.WithBedrock
 {
+
+    public static class MyPayloadTypeStrings
+    {
+        public const string Init = "INIT";
+        public const string Payload = "MESSAGE";
+
+        public static string ToString(this MyPayloadType myPayloadType) =>
+            myPayloadType switch
+            {
+                MyPayloadType.Init => Init,
+                MyPayloadType.Payload => Payload,
+                _ => throw new InvalidDataException($"Expected '{nameof(MyPayloadType)}' to be of type {myPayloadType.GetType().Name}.")
+            };
+    }
+
     public enum MyPayloadType
     {
         Init,
@@ -10,5 +27,4 @@
 
     public record InitMessage(string Source) : MyRequestMessage(Source, MyPayloadType.Init);
     public record PayloadMessage(string Source, string Destination, string Payload) : MyRequestMessage(Source, MyPayloadType.Payload);
-
 }

--- a/src/TerminalGame.RelayServer.WithBedrock/MyRequestMessageWriter.cs
+++ b/src/TerminalGame.RelayServer.WithBedrock/MyRequestMessageWriter.cs
@@ -18,9 +18,7 @@ namespace TerminalGame.RelayServer.WithBedrock
 
         private static void WriteHeaders(MyRequestMessage message, IBufferWriter<byte> stream)
         {
-            // HACK : Send an arbitrary number right now because all message have that size during test
-            var size = message is InitMessage ? 35 : 77;
-            // HACK
+            var size = MyRequestMessageExtensions.GetMessageLength(message);
 
             var sizeSpan = stream.GetSpan(4);
             BinaryPrimitives.WriteInt32BigEndian(sizeSpan, size);
@@ -75,8 +73,8 @@ namespace TerminalGame.RelayServer.WithBedrock
 
         public const string PayloadTypePropertyName = "payloadType";
         public static readonly JsonEncodedText PayloadTypePropertyNameBytes = JsonEncodedText.Encode(PayloadTypePropertyName);
-        public static readonly JsonEncodedText PayloadTypeInitPropertyValue = JsonEncodedText.Encode("INIT");
-        public static readonly JsonEncodedText PayloadTypePayloadPropertyValue = JsonEncodedText.Encode("MESSAGE");
+        public static readonly JsonEncodedText PayloadTypeInitPropertyValue = JsonEncodedText.Encode(MyPayloadTypeStrings.Init);
+        public static readonly JsonEncodedText PayloadTypePayloadPropertyValue = JsonEncodedText.Encode(MyPayloadTypeStrings.Payload);
         private static void WritePayloadType(MyRequestMessage message, Utf8JsonWriter writer)
         {
             var payloadType = message.PayloadType switch


### PR DESCRIPTION
Super naive `Payload Length`
the `Length` needs to be properly computed by writing to a temporary `ArrayPool` (from the `Utf8JsonWriter`)
because `UTF8` encode is not at all related to how the `Utf8JsonWriter` does the encoding

Another PR will land to fix this later