### PR TITLE
Fix length writing

### DIFF
--- a/src/TerminalGame.RelayServer.WithBedrock/MyRequestMessageWriter.cs
+++ b/src/TerminalGame.RelayServer.WithBedrock/MyRequestMessageWriter.cs
@@ -22,7 +22,7 @@ namespace TerminalGame.RelayServer.WithBedrock
 
             var sizeSpan = stream.GetSpan(4);
             BinaryPrimitives.WriteInt32BigEndian(sizeSpan, size);
-            stream.Write(sizeSpan[..4]);
+            stream.Advance(4);
         }
 
         private static void WriteContent(MyRequestMessage message, IBufferWriter<byte> stream)

--- a/src/TheDesolatedTunnels.RelayServer.Core/Services/SixtyNineWriter.cs
+++ b/src/TheDesolatedTunnels.RelayServer.Core/Services/SixtyNineWriter.cs
@@ -35,7 +35,7 @@ namespace TheDesolatedTunnels.RelayServer.Core.Services
 
             var sizeSpan = stream.GetSpan(4);
             BinaryPrimitives.WriteInt32BigEndian(sizeSpan, size);
-            stream.Write(sizeSpan[..4]);
+            stream.Advance(4);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]


### PR DESCRIPTION
Previous code was already asking for a `Span` from stream :
```cs
var sizeSpan = stream.GetSpan(4);
BinaryPrimitives.WriteInt32BigEndian(sizeSpan, size);
stream.Write(sizeSpan[..4]);
```

as we can see `BinaryPrimitives.WriteInt32BigEndian(sizeSpan, size);` is already writing to the stream toward the `span`
so we just need the `stream` to call
```cs
stream.Advance(4)
```

It avoid `.Write` to attempts a Copy + Advance internally